### PR TITLE
Update minecraft versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-val baseVersion = "0.0.1"
+val baseVersion = "0.0.2"
 val commitHash = System.getenv("COMMIT_HASH")
 val snapshotversion = "${baseVersion}-dev.$commitHash"
 

--- a/sign-paper/build.gradle.kts
+++ b/sign-paper/build.gradle.kts
@@ -42,7 +42,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("paper")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the `modrinth` configuration in the `sign-paper/build.gradle.kts` file to include support for additional Minecraft versions.

* Added support for Minecraft versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` in the `modrinth` configuration. (`[sign-paper/build.gradle.ktsL45-R49](diffhunk://#diff-7604d6598df46aabb042f69222022fc0dc006eca04ccb07ef8036c338c0bddf2L45-R49)`)